### PR TITLE
Refactor get_todos method to use user_id parameter

### DIFF
--- a/lib/bloomy/operations/todos.rb
+++ b/lib/bloomy/operations/todos.rb
@@ -1,8 +1,9 @@
 module Bloomy
   module TodoOperations
-    def get_my_todos
-      response = @conn.get('todo/users/mine').body
-      todos = response.map do |todo|
+    include Bloomy::UserOperations
+    def get_todos(user_id: get_my_user_id)
+      response = @conn.get("todo/user/#{get_my_user_id}").body
+      response.map do |todo|
         {
           id: todo['Id'],
           title: todo['Name'],

--- a/spec/bloomy_todos_spec.rb
+++ b/spec/bloomy_todos_spec.rb
@@ -1,9 +1,10 @@
-RSpec.describe "Todo Operations" do
+RSpec.describe Bloomy::TodoOperations do
   let(:client) { Bloomy::Client.new }
+  let(:user_id) { client.get_my_user_id }
 
-  context "when interacting with todos API", :vcr do
-    it "returns my pending todos", :vcr do
-      todos = client.get_my_todos
+  context "when interacting with todos API" do
+    it "returns user pending todos" do
+      todos = client.get_todos(user_id: user_id)
       expect(todos).to include(
         {
           id: a_kind_of(Integer),


### PR DESCRIPTION
This pull request refactors the get_todos method in the TodoOperations module to accept a user_id parameter. This allows for more flexibility in retrieving todos for a specific user.