### PR TITLE
Update GitHub Actions to use specific versions for artifact upload and deployment

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           # Upload entire repository
-          path: 'doc'
+          path: "doc"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
Specify versions for `upload-pages-artifact` and `deploy-pages` to ensure consistent behavior in the CI/CD pipeline.