### PR TITLE
Rename `details_url` to `notes_url`

### DIFF
--- a/lib/bloomy/operations/headlines.rb
+++ b/lib/bloomy/operations/headlines.rb
@@ -27,7 +27,7 @@ class Headline
       id: response.body["Id"],
       title: response.body["Title"],
       owner_id: response.body["OwnerId"],
-      notes: response.body["Notes"]
+      notes_url: response.body["DetailsUrl"]
     }
   end
 
@@ -53,6 +53,7 @@ class Headline
     {
       id: response.body["Id"],
       title: response.body["Name"],
+      notes_url: response.body["DetailsUrl"],
       meeting_details: {
         id: response.body["OriginId"],
         name: response.body["Origin"]

--- a/lib/bloomy/operations/issues.rb
+++ b/lib/bloomy/operations/issues.rb
@@ -9,7 +9,6 @@ class Issue
   # Initializes a new Issue instance
   #
   # @param conn [Object] the connection object to interact with the API
-  # @param user_id [Integer] the ID of the user
   def initialize(conn)
     @conn = conn
   end
@@ -91,7 +90,7 @@ class Issue
       meeting_title: response.body["Origin"],
       title: response.body["Name"],
       user_id: response.body["Owner"]["Id"],
-      details_url: response.body["DetailsUrl"]
+      notes_url: response.body["DetailsUrl"]
     }
   end
 end

--- a/lib/bloomy/operations/todos.rb
+++ b/lib/bloomy/operations/todos.rb
@@ -27,6 +27,7 @@ class Todo
       {
         id: todo["Id"],
         title: todo["Name"],
+        notes_url: todo["DetailsUrl"],
         due_date: todo["DueDate"],
         created_at: todo["CreateTime"],
         completed_at: todo["CompleteTime"],
@@ -57,7 +58,7 @@ class Todo
       meeting_name: response["Origin"],
       meeting_id: response["OriginId"],
       due_date: response["DueDate"],
-      details_url: response["DetailsUrl"]
+      notes_url: response["DetailsUrl"]
     }
   end
 
@@ -97,6 +98,31 @@ class Todo
       title: title,
       due_date: due_date,
       updated_at: DateTime.now.to_s
+    }
+  end
+
+  # Retrieves the details of a specific todo item by its ID.
+  #
+  # @param todo_id [String] The ID of the todo item to retrieve.
+  # @return [Hash] A hash containing the details of the todo item.
+  # @raise [RuntimeError] If the request to retrieve the todo details fails.
+  # @example
+  #  client.todo.details(1)
+  #  #=> { id: 1, title: "Updated Todo", due_date: "2024-11-01T01:41:41.528Z", ... }
+  def details(todo_id)
+    response = @conn.get("/api/v1/todo/#{todo_id}")
+    raise "Failed to get todo details. Status: #{response.status}" unless response.success?
+
+    todo = response.body
+    {
+      id: todo["Id"],
+      meeting_id: todo["OriginId"],
+      title: todo["Name"],
+      notes_url: todo["DetailsUrl"],
+      due_date: todo["DueDate"],
+      created_at: todo["CreateTime"],
+      completed_at: todo["CompleteTime"],
+      status: todo["Complete"] ? "Complete" : "Incomplete"
     }
   end
 end

--- a/spec/bloomy_headlines_spec.rb
+++ b/spec/bloomy_headlines_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Headline Operations" do
 
   # Create a headline before each test
   before(:each) do
-    @headline_id = @client.headline.create(@meeting_id, "Test Headline")[:id]
+    @headline_id = @client.headline.create(@meeting_id, "Test Headline", notes: "Note!")[:id]
   end
 
   context "when managing headlines" do
@@ -32,6 +32,7 @@ RSpec.describe "Headline Operations" do
       expect(headline[:title]).to eq("Test Headline")
       expect(headline[:meeting_details][:id]).to eq(@meeting_id)
       expect(headline[:meeting_details][:name]).to eq("Test Meeting")
+      expect(headline[:notes_url]).not_to be_nil
     end
 
     it "gets user headlines" do

--- a/spec/bloomy_issues_spec.rb
+++ b/spec/bloomy_issues_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Issue Operations" do
   before(:all) do
     @client = Bloomy::Client.new
     @meeting_id = @client.meeting.create(title: "Test Meeting")[:meeting_id]
-    @issue = @client.issue.create(meeting_id: @meeting_id, title: "Test Issue")
+    @issue = @client.issue.create(meeting_id: @meeting_id, title: "Test Issue", notes: "Note!")
     @issue_id = @issue[:id]
   end
 
@@ -23,6 +23,7 @@ RSpec.describe "Issue Operations" do
       details = @client.issue.details(@issue_id)
       expect(details[:title]).to eq("Test Issue")
       expect(details[:meeting_details][:id]).to eq(@meeting_id)
+      expect(details[:notes_url]).not_to be_nil
     end
 
     it "completes an issue" do

--- a/spec/bloomy_todos_spec.rb
+++ b/spec/bloomy_todos_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Todo Operations" do
           meeting_id: eq(@meeting_id),
           meeting_name: a_kind_of(String),
           due_date: a_kind_of(String),
-          details_url: a_kind_of(String)
+          notes_url: a_kind_of(String)
         }
       )
     end
@@ -37,6 +37,18 @@ RSpec.describe "Todo Operations" do
       )
     end
 
+    it "gets todo details" do
+      todo_details = @client.todo.details(@todo[:id])
+      expect(todo_details).to include(
+        id: eq(@todo[:id]),
+        title: eq("Updated Todo"),
+        due_date: a_kind_of(String),
+        created_at: a_kind_of(String),
+        completed_at: nil,
+        status: eq("Incomplete")
+      )
+    end
+
     it "lists all todos" do
       todos = @client.todo.list
       expect(todos).to include(
@@ -46,7 +58,8 @@ RSpec.describe "Todo Operations" do
           due_date: a_kind_of(String),
           created_at: a_kind_of(String),
           completed_at: a_kind_of(String),
-          status: eq("Complete").or(eq("Incomplete"))
+          status: eq("Complete").or(eq("Incomplete")),
+          notes_url: a_kind_of(String)
         }
       )
     end


### PR DESCRIPTION
Update references from `details_url` to `notes_url` across the codebase to improve clarity and consistency.