### PR TITLE
Remove leftover VCR references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,3 @@ Gemfile.lock
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,ruby,direnv
 
-# Filter out VCR fixtures and cassettes
-/spec/fixtures/vcr_cassettes/*

--- a/spec/bloomy_config_spec.rb
+++ b/spec/bloomy_config_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Config Operations" do
   let(:config_file) { File.expand_path("~/.bloomy/config.yaml") }
   let(:config) { Bloomy::Configuration.new }
 
-  context "when configuring the API key", :vcr do
+  context "when configuring the API key" do
     before do
       FileUtils.rm_f(config_file)
       config.configure_api_key(username, password, store_key: true)


### PR DESCRIPTION
## Summary
- remove the `:vcr` tag from `bloomy_config_spec.rb`
- clean `.gitignore` by deleting the VCR cassettes entry

## Testing
- `bundle exec rake spec` *(fails: could not find gem 'rspec')*